### PR TITLE
Change canonical API to CES

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Armington"
 uuid = "448fece5-6e02-4dfe-bf33-b4920090d0e2"
 authors = ["Miguel Olivo-Villabrille"]
-version = "0.3.3"
+version = "0.4.0"
 
 [compat]
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ Pkg.add("Armington")
 using Armington
 
 # Two-level Armington: domestic vs. imports (US, EU)
-imports = CESNode(4.0, (0.6, 0.4), (CESLeaf(:US), CESLeaf(:EU)); name=:imports)
-tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:dom), imports); name=:total)
+imports = CES(4.0, (0.6, 0.4), (:US, :EU); name=:imports)
+tree = CES(1.5, (0.7, 0.3), (:dom, imports); name=:total)
 
 leaf_names(tree)            # [:dom, :US, :EU]
 aggregate(tree, [10, 5, 8]) # CES composite quantity
 show_tree(tree)             # print nesting structure
 ```
 
-```
-total: CESNode(σ=1.5, α=(0.7, 0.3))
+```julia
+total: CES(σ=1.5, α=(0.7, 0.3))
   └ dom
-  └ imports: CESNode(σ=4.0, α=(0.6, 0.4))
+  └ imports: CES(σ=4.0, α=(0.6, 0.4))
     └ US
     └ EU
 ```
@@ -41,17 +41,20 @@ total: CESNode(σ=1.5, α=(0.7, 0.3))
 
 **`CESLeaf(name::Symbol)`** — terminal node (a single good/input). `CESLeaf()` creates an anonymous leaf.
 
-**`CESNode(σ, α, children; name)`**: interior CES node.
+**`CES(σ, α, children; name)`**: interior CES node.
 - `σ`: elasticity of substitution (σ ≥ 0, including `Inf`)
 - `α`: distribution parameters (tuple, one per child)
-- `children`: tuple of `CESNode` or `CESLeaf`
+- `children`: tuple of `CES`, `CESLeaf`, `Symbol`, or `AbstractString`. Symbols and strings are converted to named leaves, so `(:steel, :aluminum)` is shorthand for `(CESLeaf(:steel), CESLeaf(:aluminum))`.
 - `name`: optional keyword, a `Symbol` for display purposes
 
 If `children` is omitted, anonymous leaves are created from the length of `α`:
 
 ```julia
-CESNode(2.0, (0.5, 0.5))  # two anonymous leaves
+CES(2.0, (0.5, 0.5))                    # two anonymous leaves
+CES(2.0, (0.5, 0.5), (:steel, :alum))   # two named leaves via symbol shorthand
 ```
+
+> `CESNode` and `CESNode_ρ` are aliases for `CES` and `CES_ρ`, for compatibility with code written against earlier versions.
 
 ### Functions
 
@@ -61,7 +64,7 @@ CESNode(2.0, (0.5, 0.5))  # two anonymous leaves
 
 **`show_tree(tree)`**: print the full nesting structure of the tree.
 
-**`CESNode_ρ(ρ, α, children; name)`**: construct a `CESNode` using ρ = (σ−1)/σ instead of σ. Useful when you think in terms of the substitution parameter directly.
+**`CES_ρ(ρ, α, children; name)`**: construct a `CES` using ρ = (σ−1)/σ instead of σ. Useful when you think in terms of the substitution parameter directly.
 
 ### Limiting cases
 
@@ -81,30 +84,30 @@ $$ imports = \left( \alpha_{imp_1} US^{\rho_{imp}} + \alpha_{imp_2} EU^{\rho_{im
 $$ Q = \left( \alpha_1 domestic^{\rho} + \alpha_2 imports^{\rho} \right)^{1/{\rho}} $$
 ```julia
 # Varieties within each origin
-us = CESNode(8.0, (0.5, 0.5), (CESLeaf(:US_east), CESLeaf(:US_west)); name=:us)
-eu = CESNode(8.0, (0.6, 0.4), (CESLeaf(:EU_north), CESLeaf(:EU_south)); name=:eu)
+us = CES(8.0, (0.5, 0.5), (:US_east, :US_west); name=:us)
+eu = CES(8.0, (0.6, 0.4), (:EU_north, :EU_south); name=:eu)
 
 # Origins within imports
-imports = CESNode(4.0, (0.55, 0.45), (us, eu); name=:imports)
+imports = CES(4.0, (0.55, 0.45), (us, eu); name=:imports)
 
 # Domestic vs. import composite
-Q = CESNode(1.5, (0.7, 0.3), (CESLeaf(:domestic), imports); name=:total)
+Q = CES(1.5, (0.7, 0.3), (:domestic, imports); name=:total)
 
 aggregate(Q, [20.0, 5.0, 4.0, 6.0, 3.0])
 ```
 
 ### Display tree structure
 
-```
+```julia
 show_tree(Q)
 
-total: CESNode(σ=1.5, α=(0.7, 0.3))
+total: CES(σ=1.5, α=(0.7, 0.3))
   └ domestic
-  └ imports: CESNode(σ=4.0, α=(0.55, 0.45))
-    └ us: CESNode(σ=8.0, α=(0.5, 0.5))
+  └ imports: CES(σ=4.0, α=(0.55, 0.45))
+    └ us: CES(σ=8.0, α=(0.5, 0.5))
       └ US_east
       └ US_west
-    └ eu: CESNode(σ=8.0, α=(0.6, 0.4))
+    └ eu: CES(σ=8.0, α=(0.6, 0.4))
       └ EU_north
       └ EU_south
 ```

--- a/src/Armington.jl
+++ b/src/Armington.jl
@@ -1,6 +1,6 @@
 module Armington
 
-export CESLeaf, CESNode, aggregate, leaf_names, CESNode_ρ, show_tree
+export CESLeaf, CES, CESNode, aggregate, leaf_names, CES_ρ, CESNode_ρ, show_tree
 
 # ─────────────────────────────────────────────────────────────
 # Types
@@ -20,7 +20,7 @@ CESLeaf(name::AbstractString) = CESLeaf(Symbol(name))
 CESLeaf() = CESLeaf(Symbol())
 
 """
-    CESNode(σ, α, children)
+    CES(σ, α, children)
 
 Interior node in a CES nesting tree.
 
@@ -31,53 +31,79 @@ Interior node in a CES nesting tree.
         σ = Inf  → Linear
 - `α`: Distribution parameters. A `Tuple` of length `N`, one per child.
         These enter the CES directly: U = (Σ αᵢ xᵢ^ρ)^(1/ρ) with ρ = (σ-1)/σ.
-- `children`: `Tuple` of `CESNode` or `CESLeaf`, one per distribution parameter.
+- `children`: `Tuple` of `CES`, `CESLeaf`, `Symbol`, or `AbstractString` (one per
+        distribution parameter). Symbols and strings are converted to named
+        `CESLeaf` instances, so `CES(σ, (0.5, 0.5), (:steel, :aluminum))` is
+        shorthand for `CES(σ, (0.5, 0.5), (CESLeaf(:steel), CESLeaf(:aluminum)))`.
 
 If `children` is omitted, anonymous leaves are created automatically
 (one per element of α):
 
-    CESNode(2.0, (0.5, 0.5))  # equivalent to CESNode(2.0, (0.5, 0.5), (CESLeaf(), CESLeaf()))
+    CES(2.0, (0.5, 0.5))  # equivalent to CES(2.0, (0.5, 0.5), (CESLeaf(), CESLeaf()))
 
 """
-struct CESNode{T<:Real, N, C<:Tuple}
+struct CES{T<:Real, N, C<:Tuple}
     name::Symbol
     σ::T
     α::NTuple{N, T}
     children::C
 
-    function CESNode(σ::T, α::NTuple{N, T}, children::C; name::Symbol = Symbol()) where {T<:Real, N, C<:Tuple}
-        length(children) == N || throw(ArgumentError(
-            "Length of α ($(N)) must equal number of children ($(length(children)))."
+    function CES(σ::T, α::NTuple{N, T}, children::Tuple; name::Symbol = Symbol()) where {T<:Real, N}
+        normalized = map(_to_leaf, children)
+        length(normalized) == N || throw(ArgumentError(
+            "Length of α ($(N)) must equal number of children ($(length(normalized)))."
         ))
         σ >= 0 || throw(ArgumentError("Elasticity σ must be non-negative, got $σ."))
         all(a -> a > 0, α) || throw(ArgumentError("All distribution parameters α must be positive."))
-        new{T, N, C}(name, σ, α, children)
+        C = typeof(normalized)
+        new{T, N, C}(name, σ, α, normalized)
     end
 end
 
 # Promote σ and α to a common type
-function CESNode(σ::Real, α::NTuple{N, Real}, children::Tuple; name::Symbol = Symbol()) where {N}
-    T = promote_type(typeof(σ), eltype(α))
-    CESNode(convert(T, σ), convert(NTuple{N, T}, α), children; name)
+function CES(σ::Real, α::NTuple{N, Real}, children::Tuple; name::Symbol = Symbol()) where {N}
+    T = promote_type(typeof(σ), typeof.(α)...)
+    CES(convert(T, σ), convert(NTuple{N, T}, α), children; name)
 end
 
 # Convenience: accept vectors / non-tuple iterables
-function CESNode(σ::Real, α, children; name::Symbol = Symbol())
-    CESNode(σ, Tuple(α), Tuple(children); name)
+function CES(σ::Real, α, children; name::Symbol = Symbol())
+    CES(σ, Tuple(α), Tuple(children); name)
 end
 
 # Leaf-free: create anonymous leaves from α length
-function CESNode(σ::Real, α::Union{Tuple, AbstractVector}; name::Symbol = Symbol())
+function CES(σ::Real, α::Union{Tuple, AbstractVector}; name::Symbol = Symbol())
     leaves = ntuple(_ -> CESLeaf(), length(α))
-    CESNode(σ, α, leaves; name)
+    CES(σ, α, leaves; name)
 end
 
-const CESTree = Union{CESLeaf, CESNode}
+# Normalize a child input to a tree element. Symbols and strings are
+# promoted to named leaves; existing leaves and nodes pass through.
+# Anything else throws with an informative message; this is what lets
+# `CES(σ, α, (:steel, :aluminum))` work as shorthand for
+# `CES(σ, α, (CESLeaf(:steel), CESLeaf(:aluminum)))`.
+_to_leaf(s::Symbol) = CESLeaf(s)
+_to_leaf(s::AbstractString) = CESLeaf(s)
+_to_leaf(l::CESLeaf) = l
+_to_leaf(n::CES) = n
+_to_leaf(x) = throw(ArgumentError(
+    "Children must be CESLeaf, CES, Symbol, or AbstractString, got $(typeof(x))."
+))
+
+const CESTree = Union{CESLeaf, CES}
 
 """
-    CESNode_ρ(ρ, α, children)
+    CESNode
 
-Construct a `CESNode` parametrized by ρ = (σ-1)/σ instead of σ.
+Alias for [`CES`](@ref). Retained for compatibility with code written
+against earlier versions of the package; `CES` is the canonical name.
+"""
+const CESNode = CES
+
+"""
+    CES_ρ(ρ, α, children)
+
+Construct a `CES` parametrized by ρ = (σ-1)/σ instead of σ.
 
 The mapping is σ = 1/(1-ρ), with ρ ∈ (-∞, 1):
 - ρ → -∞  ⟹  σ → 0   (Leontief)
@@ -86,11 +112,19 @@ The mapping is σ = 1/(1-ρ), with ρ ∈ (-∞, 1):
 
 The node stores σ internally; this is purely a convenience for construction.
 """
-function CESNode_ρ(ρ::Real, α, children; name::Symbol = Symbol())
+function CES_ρ(ρ::Real, α, children; name::Symbol = Symbol())
     ρ < 1 || throw(ArgumentError("ρ must be < 1, got $ρ."))
     σ = 1 / (1 - ρ)
-    CESNode(σ, α, children; name)
+    CES(σ, α, children; name)
 end
+
+"""
+    CESNode_ρ
+
+Alias for [`CES_ρ`](@ref). Retained for compatibility with code written
+against earlier versions of the package; `CES_ρ` is the canonical name.
+"""
+const CESNode_ρ = CES_ρ
 
 # ─────────────────────────────────────────────────────────────
 # Tree introspection
@@ -103,23 +137,27 @@ Return leaf names in depth-first order. This is the order in which
 a flat input vector is expected by `aggregate`.
 """
 leaf_names(leaf::CESLeaf) = [leaf.name]
-leaf_names(node::CESNode) = mapreduce(leaf_names, vcat, node.children)
+leaf_names(node::CES) = mapreduce(leaf_names, vcat, node.children)
 
 """Number of leaves in the tree."""
 _nleaves(::CESLeaf) = 1
-_nleaves(node::CESNode) = sum(_nleaves, node.children)
+_nleaves(node::CES) = sum(_nleaves, node.children)
 
 # ─────────────────────────────────────────────────────────────
 # Display
 # ─────────────────────────────────────────────────────────────
 
 function Base.show(io::IO, leaf::CESLeaf)
-    print(io, "CESLeaf(:", leaf.name, ")")
+    if leaf.name == Symbol()
+        print(io, "CESLeaf()")
+    else
+        print(io, "CESLeaf(:", leaf.name, ")")
+    end
 end
 
-function Base.show(io::IO, node::CESNode{T,N}) where {T,N}
+function Base.show(io::IO, node::CES{T,N}) where {T,N}
     label = node.name == Symbol() ? "" : string(node.name, ": ")
-    print(io, label, "CESNode(σ=", node.σ, ", α=", node.α, ", ", N, " children)")
+    print(io, label, "CES(σ=", node.σ, ", α=", node.α, ", ", N, " children)")
 end
 
 """
@@ -136,9 +174,9 @@ function _show_tree(io::IO, leaf::CESLeaf, depth::Int, prefix::String)
     println(io, "  "^depth, prefix, label)
 end
 
-function _show_tree(io::IO, node::CESNode{T,N}, depth::Int, prefix::String) where {T,N}
+function _show_tree(io::IO, node::CES{T,N}, depth::Int, prefix::String) where {T,N}
     label = node.name == Symbol() ? "" : string(node.name, ": ")
-    println(io, "  "^depth, prefix, label, "CESNode(σ=", node.σ, ", α=", node.α, ")")
+    println(io, "  "^depth, prefix, label, "CES(σ=", node.σ, ", α=", node.α, ")")
     for i in 1:N
         _show_tree(io, node.children[i], depth + 1, "└ ")
     end
@@ -190,7 +228,7 @@ function _compute(::CESLeaf, x::AbstractVector, idx::Int, ::Symbol)
     return x[idx], idx + 1
 end
 
-function _compute(node::CESNode{T,N}, x::AbstractVector, idx::Int, method::Symbol) where {T,N}
+function _compute(node::CES{T,N}, x::AbstractVector, idx::Int, method::Symbol) where {T,N}
     child_vals, idx = _collect_children(node.children, x, idx, method)
     kernel = method === :lse ? _ces_lse : _ces
     return kernel(node.σ, node.α, child_vals), idx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,28 +14,51 @@ using Armington
             leaf_str = CESLeaf("B")
             @test leaf_str.name == :B
 
-            node = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            node = CES(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
             @test node.σ == 2.0
             @test node.α == (0.5, 0.5)
         end
 
         @testset "Type promotion" begin
             # Int σ with Float64 α → Float64
-            node = CESNode(2, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            node = CES(2, (0.5, 0.5), (:A, :B))
             @test node.σ isa Float64
 
             # All Int → Int (if someone really wants that)
-            node_int = CESNode(2, (1, 1), (CESLeaf(:A), CESLeaf(:B)))
+            node_int = CES(2, (1, 1), (:A, :B))
             @test node_int.σ isa Int
 
             # BigFloat
-            node_big = CESNode(big"2.0", (big"0.5", big"0.5"), (CESLeaf(:A), CESLeaf(:B)))
+            node_big = CES(big"2.0", (big"0.5", big"0.5"), (:A, :B))
             @test node_big.σ isa BigFloat
             @test eltype(node_big.α) == BigFloat
         end
 
+        @testset "Heterogeneous α promotion" begin
+            # Mixed Float64/Int α — promotes to Float64
+            node = CES(2.0, (0.5, 1), (:A, :B))
+            @test node.σ isa Float64
+            @test node.α isa NTuple{2, Float64}
+            @test node.α == (0.5, 1.0)
+
+            # Int σ with mixed-numeric α
+            node2 = CES(2, (0.5, 1), (:A, :B))
+            @test node2.σ isa Float64
+            @test node2.α === (0.5, 1.0)
+
+            # All-Int α with Float σ — already covered indirectly but worth pinning
+            node3 = CES(2.0, (1, 1), (:A, :B))
+            @test node3.σ isa Float64
+            @test node3.α === (1.0, 1.0)
+
+            # Three-element heterogeneous
+            node4 = CES(2.0, (1, 0.5, big"0.25"), (:A, :B, :C))
+            @test node4.σ isa BigFloat
+            @test eltype(node4.α) == BigFloat
+        end
+
         @testset "Vector/iterable convenience" begin
-            node = CESNode(2.0, [0.5, 0.5], [CESLeaf(:A), CESLeaf(:B)])
+            node = CES(2.0, [0.5, 0.5], [:A, :B])
             @test node.α == (0.5, 0.5)
         end
 
@@ -43,41 +66,91 @@ using Armington
             leaf = CESLeaf()
             @test leaf.name == Symbol()
 
-            node = CESNode(2.0, (0.5, 0.5), (CESLeaf(), CESLeaf()))
+            node = CES(2.0, (0.5, 0.5), (CESLeaf(), CESLeaf()))
             @test aggregate(node, [4.0, 9.0]) ≈ 6.25
         end
 
         @testset "Leaf-free construction" begin
             # Two-arg form: leaves created automatically
-            node = CESNode(2.0, (0.5, 0.5))
+            node = CES(2.0, (0.5, 0.5))
             @test aggregate(node, [4.0, 9.0]) ≈ 6.25
 
             # Works with vectors too
-            node_v = CESNode(2.0, [0.5, 0.5])
+            node_v = CES(2.0, [0.5, 0.5])
             @test aggregate(node_v, [4.0, 9.0]) ≈ 6.25
 
             # Three inputs
-            node3 = CESNode(3.0, (0.4, 0.35, 0.25))
+            node3 = CES(3.0, (0.4, 0.35, 0.25))
             @test aggregate(node3, [2.0, 3.0, 4.0]) > 0
         end
 
         @testset "Leaf-free nesting" begin
             # Inner node with anonymous leaves, outer with named + nested
-            inner = CESNode(4.0, (0.6, 0.4))
-            tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:dom), inner))
+            inner = CES(4.0, (0.6, 0.4))
+            tree = CES(1.5, (0.7, 0.3), (:dom, inner))
             @test aggregate(tree, [1.0, 1.0, 1.0]) > 0
         end
 
+        @testset "Symbol shorthand for leaves" begin
+            # Tuple of symbols is normalized to tuple of named CESLeaf
+            node = CES(2.0, (0.5, 0.5), (:steel, :aluminum))
+            @test node.children[1] isa CESLeaf
+            @test node.children[1].name === :steel
+            @test node.children[2].name === :aluminum
+
+            # Equivalent to explicit construction
+            explicit = CES(2.0, (0.5, 0.5), (CESLeaf(:steel), CESLeaf(:aluminum)))
+            @test node.children == explicit.children
+            @test typeof(node) == typeof(explicit)
+
+            # Mixed: symbol + CESLeaf + nested CES
+            inner = CES(3.0, (0.6, 0.4))
+            mixed = CES(1.5, (0.5, 0.3, 0.2), (:dom, CESLeaf(:imp), inner))
+            @test mixed.children[1].name === :dom
+            @test mixed.children[2].name === :imp
+            @test mixed.children[3] === inner
+
+            # Strings also work
+            from_str = CES(2.0, (0.5, 0.5), ("a", "b"))
+            @test from_str.children[1].name === :a
+
+            # Aggregation works through normalized children
+            @test aggregate(node, [4.0, 9.0]) ≈ aggregate(explicit, [4.0, 9.0])
+
+            # Leaf names recoverable via leaf_names
+            @test leaf_names(node) == [:steel, :aluminum]
+
+            # Invalid child type rejected at construction
+            @test_throws ArgumentError CES(2.0, (0.5, 0.5), (1, 2))
+        end
+
+        @testset "CESNode back-compat alias" begin
+            # CESNode is retained as an alias for CES
+            @test CESNode === CES
+            @test CESNode_ρ === CES_ρ
+
+            # Old-style construction still works
+            old = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            via_ces = CES(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            @test typeof(old) == typeof(via_ces)
+            @test aggregate(old, [4.0, 9.0]) ≈ aggregate(via_ces, [4.0, 9.0])
+
+            # ρ-constructor alias
+            old_ρ = CESNode_ρ(0.5, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            via_ces_ρ = CES_ρ(0.5, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            @test old_ρ.σ == via_ces_ρ.σ
+        end
+
         @testset "Invalid construction" begin
-            @test_throws ArgumentError CESNode(-1.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
-            @test_throws ArgumentError CESNode(2.0, (0.5, -0.1), (CESLeaf(:A), CESLeaf(:B)))
-            @test_throws ArgumentError CESNode(2.0, (0.5,), (CESLeaf(:A), CESLeaf(:B)))
+            @test_throws ArgumentError CES(-1.0, (0.5, 0.5), (:A, :B))
+            @test_throws ArgumentError CES(2.0, (0.5, -0.1), (:A, :B))
+            @test_throws ArgumentError CES(2.0, (0.5,), (:A, :B))
         end
 
         @testset "Limiting σ values accepted" begin
-            leon = CESNode(0.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            leon = CES(0.0, (0.5, 0.5), (:A, :B))
             @test leon.σ == 0.0
-            lin = CESNode(Inf, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            lin = CES(Inf, (0.5, 0.5), (:A, :B))
             @test isinf(lin.σ)
         end
     end
@@ -86,15 +159,15 @@ using Armington
     # Tree introspection
     # ================================================================
     @testset "Tree introspection" begin
-        inner = CESNode(3.0, (0.6, 0.4), (CESLeaf(:US), CESLeaf(:EU)))
-        tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:dom), inner))
+        inner = CES(3.0, (0.6, 0.4), (:US, :EU))
+        tree = CES(1.5, (0.7, 0.3), (:dom, inner))
 
         @test leaf_names(tree) == [:dom, :US, :EU]
         @test leaf_names(CESLeaf(:solo)) == [:solo]
 
-        sub = CESNode(5.0, (0.5, 0.5), (CESLeaf(:v1), CESLeaf(:v2)))
-        mid = CESNode(3.0, (0.4, 0.6), (sub, CESLeaf(:C)))
-        top = CESNode(1.5, (0.5, 0.5), (CESLeaf(:A), mid))
+        sub = CES(5.0, (0.5, 0.5), (:v1, :v2))
+        mid = CES(3.0, (0.4, 0.6), (sub, :C))
+        top = CES(1.5, (0.5, 0.5), (:A, mid))
         @test leaf_names(top) == [:A, :v1, :v2, :C]
     end
 
@@ -103,8 +176,8 @@ using Armington
     # ================================================================
     @testset "Display" begin
         # Compact show
-        tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:dom),
-            CESNode(4.0, (0.6, 0.4), (CESLeaf(:US), CESLeaf(:EU)))))
+        tree = CES(1.5, (0.7, 0.3), (:dom,
+            CES(4.0, (0.6, 0.4), (:US, :EU))))
         str = sprint(show, tree)
         @test occursin("σ=1.5", str)
         @test occursin("2 children", str)
@@ -112,13 +185,14 @@ using Armington
 
         # Leaf display
         @test sprint(show, CESLeaf(:A)) == "CESLeaf(:A)"
+        @test sprint(show, CESLeaf()) == "CESLeaf()"
 
         # Named node compact show
-        named = CESNode(2.0, (0.5, 0.5); name=:test)
-        @test occursin("test: CESNode", sprint(show, named))
+        named = CES(2.0, (0.5, 0.5); name=:test)
+        @test occursin("test: CES", sprint(show, named))
 
         # Unnamed compact show
-        @test startswith(sprint(show, CESNode(2.0, (0.5, 0.5))), "CESNode")
+        @test startswith(sprint(show, CES(2.0, (0.5, 0.5))), "CES")
 
         # show_tree: full tree display
         tree_str = sprint(show_tree, tree)
@@ -130,17 +204,17 @@ using Armington
         @test occursin("└", tree_str)
 
         # show_tree: anonymous leaves show bullet
-        anon_tree = CESNode(2.0, (0.5, 0.5))
+        anon_tree = CES(2.0, (0.5, 0.5))
         anon_str = sprint(show_tree, anon_tree)
         @test occursin("•", anon_str)
 
         # show_tree: named nodes
-        named_tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:dom),
-            CESNode(4.0, (0.6, 0.4), (CESLeaf(:US), CESLeaf(:EU)); name=:imports));
+        named_tree = CES(1.5, (0.7, 0.3), (:dom,
+            CES(4.0, (0.6, 0.4), (:US, :EU); name=:imports));
             name=:total)
         named_str = sprint(show_tree, named_tree)
-        @test occursin("total: CESNode", named_str)
-        @test occursin("imports: CESNode", named_str)
+        @test occursin("total: CES", named_str)
+        @test occursin("imports: CES", named_str)
     end
 
     # ================================================================
@@ -148,19 +222,19 @@ using Armington
     # ================================================================
     @testset "General CES" begin
         @testset "Equal weights, equal inputs" begin
-            tree = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(2.0, (0.5, 0.5), (:A, :B))
             @test aggregate(tree, [1.0, 1.0]) ≈ 1.0
         end
 
         @testset "Known analytic value (σ = 2)" begin
-            tree = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(2.0, (0.5, 0.5), (:A, :B))
             # σ=2 → ρ=1/2, Q = [0.5*4^(1/2) + 0.5*9^(1/2)]^2 = 6.25
             @test aggregate(tree, [4.0, 9.0]) ≈ 6.25
         end
 
         @testset "Three inputs" begin
-            tree = CESNode(3.0, (0.4, 0.35, 0.25),
-                (CESLeaf(:A), CESLeaf(:B), CESLeaf(:C)))
+            tree = CES(3.0, (0.4, 0.35, 0.25),
+                (:A, :B, :C))
             Q = aggregate(tree, [2.0, 3.0, 4.0])
             @test Q > 0
         end
@@ -170,29 +244,29 @@ using Armington
     # Limiting cases
     # ================================================================
     @testset "Leontief (σ = 0)" begin
-        tree = CESNode(0.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+        tree = CES(0.0, (0.5, 0.5), (:A, :B))
         @test aggregate(tree, [1.0, 100.0]) ≈ 2.0
         @test aggregate(tree, [10.0, 3.0]) ≈ 6.0
 
         # Asymmetric weights
-        tree2 = CESNode(0.0, (0.25, 0.75), (CESLeaf(:A), CESLeaf(:B)))
+        tree2 = CES(0.0, (0.25, 0.75), (:A, :B))
         # min(2/0.25, 6/0.75) = min(8, 8) = 8
         @test aggregate(tree2, [2.0, 6.0]) ≈ 8.0
     end
 
     @testset "Cobb-Douglas (σ = 1)" begin
-        tree = CESNode(1.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
+        tree = CES(1.0, (0.3, 0.7), (:A, :B))
         x = [2.0, 3.0]
         expected = (2.0 / 0.3)^0.3 * (3.0 / 0.7)^0.7
         @test aggregate(tree, x) ≈ expected atol = 1e-12
 
         # Shares should work as exponents
-        tree_eq = CESNode(1.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+        tree_eq = CES(1.0, (0.5, 0.5), (:A, :B))
         @test aggregate(tree_eq, [4.0, 4.0]) ≈ (4.0 / 0.5)^0.5 * (4.0 / 0.5)^0.5
     end
 
     @testset "Linear / perfect substitutes (σ = Inf)" begin
-        tree = CESNode(Inf, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+        tree = CES(Inf, (0.6, 0.4), (:A, :B))
         @test aggregate(tree, [3.0, 7.0]) ≈ 4.6
 
         # Only one input matters
@@ -203,30 +277,30 @@ using Armington
     # Nesting
     # ================================================================
     @testset "Two-level nesting" begin
-        inner = CESNode(3.0, (0.6, 0.4), (CESLeaf(:US), CESLeaf(:EU)))
-        tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:dom), inner))
+        inner = CES(3.0, (0.6, 0.4), (:US, :EU))
+        tree = CES(1.5, (0.7, 0.3), (:dom, inner))
         Q = aggregate(tree, [1.0, 1.0, 1.0])
         @test Q > 0
     end
 
     @testset "Three-level nesting" begin
-        sub = CESNode(5.0, (0.5, 0.5), (CESLeaf(:v1), CESLeaf(:v2)))
-        mid = CESNode(3.0, (0.4, 0.6), (sub, CESLeaf(:C)))
-        top = CESNode(1.5, (0.5, 0.5), (CESLeaf(:A), mid))
+        sub = CES(5.0, (0.5, 0.5), (:v1, :v2))
+        mid = CES(3.0, (0.4, 0.6), (sub, :C))
+        top = CES(1.5, (0.5, 0.5), (:A, mid))
         Q = aggregate(top, [1.0, 1.1, 0.95, 1.3])
         @test Q > 0
     end
 
     @testset "Mixed limiting cases in nesting" begin
         # Leontief at top, high σ at bottom
-        inner = CESNode(10.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
-        tree = CESNode(0.0, (0.5, 0.5), (CESLeaf(:C), inner))
+        inner = CES(10.0, (0.5, 0.5), (:A, :B))
+        tree = CES(0.0, (0.5, 0.5), (:C, inner))
         Q = aggregate(tree, [4.0, 3.0, 5.0])
         @test Q > 0
 
         # Linear at top, Cobb-Douglas at bottom
-        inner_cd = CESNode(1.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
-        tree_lin = CESNode(Inf, (0.6, 0.4), (inner_cd, CESLeaf(:C)))
+        inner_cd = CES(1.0, (0.5, 0.5), (:A, :B))
+        tree_lin = CES(Inf, (0.6, 0.4), (inner_cd, :C))
         Q2 = aggregate(tree_lin, [2.0, 3.0, 5.0])
         @test Q2 > 0
     end
@@ -238,32 +312,32 @@ using Armington
         λ = 3.7
 
         @testset "General CES" begin
-            tree = CESNode(2.0, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(2.0, (0.6, 0.4), (:A, :B))
             x = [1.5, 2.3]
             @test aggregate(tree, λ .* x) ≈ λ * aggregate(tree, x) atol = 1e-10
         end
 
         @testset "Cobb-Douglas" begin
-            tree = CESNode(1.0, (0.4, 0.6), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(1.0, (0.4, 0.6), (:A, :B))
             x = [2.0, 5.0]
             @test aggregate(tree, λ .* x) ≈ λ * aggregate(tree, x) atol = 1e-10
         end
 
         @testset "Leontief" begin
-            tree = CESNode(0.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(0.0, (0.3, 0.7), (:A, :B))
             x = [2.0, 5.0]
             @test aggregate(tree, λ .* x) ≈ λ * aggregate(tree, x)
         end
 
         @testset "Linear" begin
-            tree = CESNode(Inf, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(Inf, (0.6, 0.4), (:A, :B))
             x = [3.0, 7.0]
             @test aggregate(tree, λ .* x) ≈ λ * aggregate(tree, x)
         end
 
         @testset "Nested" begin
-            inner = CESNode(4.0, (0.5, 0.5), (CESLeaf(:x), CESLeaf(:y)))
-            tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:A), inner))
+            inner = CES(4.0, (0.5, 0.5), (:x, :y))
+            tree = CES(1.5, (0.7, 0.3), (:A, inner))
             x = [1.0, 2.0, 1.5]
             @test aggregate(tree, λ .* x) ≈ λ * aggregate(tree, x) atol = 1e-10
         end
@@ -273,7 +347,7 @@ using Armington
     # Monotonicity: increasing any input increases Q
     # ================================================================
     @testset "Monotonicity" begin
-        tree = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+        tree = CES(2.0, (0.5, 0.5), (:A, :B))
         x = [3.0, 5.0]
         Q_base = aggregate(tree, x)
         @test aggregate(tree, [3.1, 5.0]) > Q_base
@@ -281,31 +355,31 @@ using Armington
     end
 
     # ================================================================
-    # CESNode_ρ
+    # CES_ρ
     # ================================================================
-    @testset "CESNode_ρ" begin
-        @testset "Equivalence with CESNode" begin
-            tree_rho = CESNode_ρ(0.5, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
-            tree_sig = CESNode(2.0, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+    @testset "CES_ρ" begin
+        @testset "Equivalence with CES" begin
+            tree_rho = CES_ρ(0.5, (0.6, 0.4), (:A, :B))
+            tree_sig = CES(2.0, (0.6, 0.4), (:A, :B))
             x = [3.0, 7.0]
             @test aggregate(tree_rho, x) ≈ aggregate(tree_sig, x)
         end
 
         @testset "Cobb-Douglas at ρ = 0" begin
-            tree = CESNode_ρ(0.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES_ρ(0.0, (0.3, 0.7), (:A, :B))
             x = [2.0, 3.0]
             expected = (2.0 / 0.3)^0.3 * (3.0 / 0.7)^0.7
             @test aggregate(tree, x) ≈ expected atol = 1e-12
         end
 
         @testset "Negative ρ gives complements" begin
-            tree = CESNode_ρ(-1.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES_ρ(-1.0, (0.5, 0.5), (:A, :B))
             @test tree.σ ≈ 0.5
         end
 
         @testset "Invalid ρ ≥ 1" begin
-            @test_throws ArgumentError CESNode_ρ(1.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
-            @test_throws ArgumentError CESNode_ρ(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            @test_throws ArgumentError CES_ρ(1.0, (0.5, 0.5), (:A, :B))
+            @test_throws ArgumentError CES_ρ(2.0, (0.5, 0.5), (:A, :B))
         end
     end
 
@@ -313,7 +387,7 @@ using Armington
     # Dimension checks
     # ================================================================
     @testset "Dimension mismatch" begin
-        tree = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+        tree = CES(2.0, (0.5, 0.5), (:A, :B))
         @test_throws DimensionMismatch aggregate(tree, [1.0])
         @test_throws DimensionMismatch aggregate(tree, [1.0, 2.0, 3.0])
     end
@@ -323,14 +397,14 @@ using Armington
     # ================================================================
     @testset "Type propagation" begin
         @testset "Float32 inputs" begin
-            tree = CESNode(2.0f0, (0.5f0, 0.5f0), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(2.0f0, (0.5f0, 0.5f0), (:A, :B))
             Q = aggregate(tree, Float32[4.0, 9.0])
             @test Q isa Float32
             @test Q ≈ 6.25f0
         end
 
         @testset "BigFloat inputs" begin
-            tree = CESNode(big"2.0", (big"0.5", big"0.5"), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(big"2.0", (big"0.5", big"0.5"), (:A, :B))
             Q = aggregate(tree, [big"4.0", big"9.0"])
             @test Q isa BigFloat
             @test Q ≈ big"6.25"
@@ -342,37 +416,37 @@ using Armington
     # ================================================================
     @testset "LSE method" begin
         @testset "Agrees with standard for general σ" begin
-            tree = CESNode(2.0, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(2.0, (0.6, 0.4), (:A, :B))
             x = [4.0, 9.0]
             @test aggregate(tree, x; method = :lse) ≈ aggregate(tree, x) atol = 1e-12
         end
 
         @testset "Agrees with standard for nested tree" begin
-            inner = CESNode(4.0, (0.5, 0.5), (CESLeaf(:x), CESLeaf(:y)))
-            tree = CESNode(1.5, (0.7, 0.3), (CESLeaf(:A), inner))
+            inner = CES(4.0, (0.5, 0.5), (:x, :y))
+            tree = CES(1.5, (0.7, 0.3), (:A, inner))
             x = [1.0, 2.0, 1.5]
             @test aggregate(tree, x; method = :lse) ≈ aggregate(tree, x) atol = 1e-10
         end
 
         @testset "Cobb-Douglas (σ = 1)" begin
-            tree = CESNode(1.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(1.0, (0.3, 0.7), (:A, :B))
             x = [2.0, 3.0]
             expected = (2.0 / 0.3)^0.3 * (3.0 / 0.7)^0.7
             @test aggregate(tree, x; method = :lse) ≈ expected atol = 1e-12
         end
 
         @testset "Leontief (σ = 0)" begin
-            tree = CESNode(0.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(0.0, (0.5, 0.5), (:A, :B))
             @test aggregate(tree, [1.0, 100.0]; method = :lse) ≈ 2.0
         end
 
         @testset "Linear (σ = Inf)" begin
-            tree = CESNode(Inf, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(Inf, (0.6, 0.4), (:A, :B))
             @test aggregate(tree, [3.0, 7.0]; method = :lse) ≈ 4.6
         end
 
         @testset "Homogeneity" begin
-            tree = CESNode(2.0, (0.6, 0.4), (CESLeaf(:A), CESLeaf(:B)))
+            tree = CES(2.0, (0.6, 0.4), (:A, :B))
             x = [1.5, 2.3]
             λ = 3.7
             @test aggregate(tree, λ .* x; method = :lse) ≈ λ * aggregate(tree, x; method = :lse) atol = 1e-10
@@ -385,8 +459,8 @@ using Armington
             σ_lo = 1.0 - 1e-4
             σ_hi = 1.0 + 1e-4
 
-            tree_lo = CESNode(σ_lo, α, (CESLeaf(:A), CESLeaf(:B)))
-            tree_hi = CESNode(σ_hi, α, (CESLeaf(:A), CESLeaf(:B)))
+            tree_lo = CES(σ_lo, α, (:A, :B))
+            tree_hi = CES(σ_hi, α, (:A, :B))
 
             lse_gap = abs(aggregate(tree_hi, x; method = :lse) - aggregate(tree_lo, x; method = :lse))
             std_gap = abs(aggregate(tree_hi, x) - aggregate(tree_lo, x))
@@ -399,7 +473,7 @@ using Armington
     # Invalid method keyword
     # ================================================================
     @testset "Invalid method" begin
-        tree = CESNode(2.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
+        tree = CES(2.0, (0.5, 0.5), (:A, :B))
         @test_throws ArgumentError aggregate(tree, [1.0, 2.0]; method = :bogus)
     end
 
@@ -411,13 +485,13 @@ using Armington
         # ── Flat trees ─────────────────────────────────────────
     
         @testset "Flat tree — standard" begin
-            tree = CESNode(2.0, (0.4, 0.6))
+            tree = CES(2.0, (0.4, 0.6))
             x = [3.0, 5.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
     
         @testset "Flat tree — lse" begin
-            tree = CESNode(2.0, (0.4, 0.6))
+            tree = CES(2.0, (0.4, 0.6))
             x = [3.0, 5.0]
             @test @inferred(aggregate(tree, x; method = :lse)) isa Float64
         end
@@ -425,15 +499,15 @@ using Armington
         # ── Nested tree ────────────────────────────────────────
     
         @testset "Nested tree — standard" begin
-            inner = CESNode(4.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
-            tree = CESNode(1.5, (0.5, 0.5), (CESLeaf(:C), inner))
+            inner = CES(4.0, (0.3, 0.7), (:A, :B))
+            tree = CES(1.5, (0.5, 0.5), (:C, inner))
             x = [1.0, 2.0, 3.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
     
         @testset "Nested tree — lse" begin
-            inner = CESNode(4.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
-            tree = CESNode(1.5, (0.5, 0.5), (CESLeaf(:C), inner))
+            inner = CES(4.0, (0.3, 0.7), (:A, :B))
+            tree = CES(1.5, (0.5, 0.5), (:C, inner))
             x = [1.0, 2.0, 3.0]
             @test @inferred(aggregate(tree, x; method = :lse)) isa Float64
         end
@@ -441,9 +515,9 @@ using Armington
         # ── Three levels deep ─────────────────────────────────
     
         @testset "Three-level nesting" begin
-            bottom = CESNode(3.0, (0.6, 0.4), (CESLeaf(:a), CESLeaf(:b)))
-            mid    = CESNode(2.0, (0.5, 0.5), (bottom, CESLeaf(:c)))
-            top    = CESNode(1.5, (0.7, 0.3), (CESLeaf(:d), mid))
+            bottom = CES(3.0, (0.6, 0.4), (:a, :b))
+            mid    = CES(2.0, (0.5, 0.5), (bottom, :c))
+            top    = CES(1.5, (0.7, 0.3), (:d, mid))
             x = [1.0, 2.0, 3.0, 4.0]
             @test @inferred(aggregate(top, x)) isa Float64
         end
@@ -451,19 +525,19 @@ using Armington
         # ── Limiting cases ────────────────────────────────────
     
         @testset "Leontief (σ = 0)" begin
-            tree = CESNode(0.0, (0.4, 0.6))
+            tree = CES(0.0, (0.4, 0.6))
             x = [3.0, 5.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
     
         @testset "Cobb-Douglas (σ = 1)" begin
-            tree = CESNode(1.0, (0.4, 0.6))
+            tree = CES(1.0, (0.4, 0.6))
             x = [3.0, 5.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
     
         @testset "Linear (σ = Inf)" begin
-            tree = CESNode(Inf, (0.4, 0.6))
+            tree = CES(Inf, (0.4, 0.6))
             x = [3.0, 5.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
@@ -471,8 +545,8 @@ using Armington
         # ── Limiting cases nested ─────────────────────────────
     
         @testset "Leontief nested in general CES" begin
-            inner = CESNode(0.0, (0.5, 0.5), (CESLeaf(:A), CESLeaf(:B)))
-            tree = CESNode(2.0, (0.6, 0.4), (CESLeaf(:C), inner))
+            inner = CES(0.0, (0.5, 0.5), (:A, :B))
+            tree = CES(2.0, (0.6, 0.4), (:C, inner))
             x = [1.0, 2.0, 3.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
@@ -480,7 +554,7 @@ using Armington
         # ── 3-ary node ────────────────────────────────────────
     
         @testset "3-ary node" begin
-            tree = CESNode(2.5, (0.3, 0.3, 0.4))
+            tree = CES(2.5, (0.3, 0.3, 0.4))
             x = [1.0, 2.0, 3.0]
             @test @inferred(aggregate(tree, x)) isa Float64
         end
@@ -504,8 +578,8 @@ using Armington
         # ── Internal recursion ────────────────────────────────
     
         @testset "_compute and _collect_children" begin
-            inner = CESNode(4.0, (0.3, 0.7), (CESLeaf(:A), CESLeaf(:B)))
-            tree = CESNode(1.5, (0.5, 0.5), (CESLeaf(:C), inner))
+            inner = CES(4.0, (0.3, 0.7), (:A, :B))
+            tree = CES(1.5, (0.5, 0.5), (:C, inner))
             x = [1.0, 2.0, 3.0]
     
             # _compute on a leaf returns (Float64, Int)
@@ -524,7 +598,7 @@ using Armington
         # ── BigFloat propagation ──────────────────────────────
     
         @testset "BigFloat stability" begin
-            tree = CESNode(big"2.0", (big"0.5", big"0.5"))
+            tree = CES(big"2.0", (big"0.5", big"0.5"))
             x = [big"4.0", big"9.0"]
             @test @inferred(aggregate(tree, x)) isa BigFloat
         end


### PR DESCRIPTION
Changed canonical API from CESNode to CES, and CESLeaf to a tuple of symbols or strings.